### PR TITLE
Fix for #14, no asterisk icon displaying in LI elements

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -95,7 +95,7 @@ var $post = $('.post'),
         		}
         	})
         });
-        $('li').before('<span class="bult icon-asterisk"></span>')
+        $('li').before('<span class="bult fa fa-asterisk icon-asterisk"></span>')
         $('blockquote p').prepend('<span class="quo icon-quote-left"></span>')
             .append('<span class="quo icon-quote-right"></span>')
 


### PR DESCRIPTION
Fixes Issue #14, Added "fa" and "fa-asterisk" class to `<span>` that is placed before the `<li>` in index.js.

![screen shot 2014-02-28 at 11 26 51 am](https://f.cloud.github.com/assets/1444370/2295791/2ca86c6c-a095-11e3-9e9a-9aa8235f7b86.png)
