### PR TITLE
Allow article reference by id

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -51,7 +51,6 @@ var $post = $('.post'),
         	var t = $(this).text(),
         	    index = $(this).parents('.post-holder').index();
         	$fnav.append("<a class='fn-item' item_index='"+index+"'>"+t+"</a>")
-		//
         	$(this).parents('article').attr('id',t.toLowerCase().split(' ').join('-'));
         	$('.fn-item').click(function () {
         		var i = $(this).attr('item_index'),


### PR DESCRIPTION
Useful for linking to specific articles without breaking out of the scrolling format.

For example, http://yourwebsite.com/#Post Title Here now jumps to the correct post. I don't believe there was a way to do this before, unless you wanted to show only that post (in which case you can't scroll).
