### PR TITLE
Revert "Add paralex header like all the cool kids"

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -938,7 +938,6 @@ a.fn-item.active {
         padding: 15% 0;
         height: 100%;
         margin-bottom: 0rem;
-        background-position-y: 50%;
     }
 
     .blog-title {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -66,9 +66,6 @@ var $sitehead = $('#site-head');
 				var w = $(window).scrollTop();
 				var g = $sitehead.offset().top;
 				var h = $sitehead.offset().top + $sitehead.height()-100;
-				
-				var paralex = 30 + w/13 + "%";
-				$sitehead.css("background-position-y", paralex);
 
 				if(w >= g && w<=h) {
 					$('.fixed-nav').fadeOut('fast');


### PR DESCRIPTION
This reverts commit 7321ed91c7e40b81908992bd30723bcccf1fab5f.

This caused flickery/laggy scrolling...

One would probably have to be more careful about updating the `"background-position-y"` attribute. Maybe use `requestAnimationFrame`. For now I believe it is better left without parallax.
