### PR TITLE
Let the browser decide whether to load fonts over ssl or not

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -25,9 +25,9 @@
     {{! Styles'n'Scripts }}
     <link rel="stylesheet" type="text/css" href='{{ asset "css/screen.css" }}' />
 
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,300italic,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans+Condensed:300,300italic,700' rel='stylesheet' type='text/css'>
 
-    <link href='http://fonts.googleapis.com/css?family=Oswald:400,300,700|Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800|Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Oswald:400,300,700|Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800|Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <link rel="stylesheet" href='{{asset "font-awesome/css/font-awesome.min.css"}}'>
 


### PR DESCRIPTION
Otherwise Chrome will not load these assets when the site is served from a `https://` url.

See http://stackoverflow.com/questions/18026809/google-web-fonts-on-https-pages-on-chrome