### PR TITLE
Add click listener to correct fn-item

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -49,7 +49,7 @@ var $sitehead = $('#site-head');
 			var index = $(this).parents('.post-holder').index();
 			$fnav.append("<a class='fn-item' item_index='"+index+"'>"+t+"</a>")
 			$(this).parents('article').attr('id',t.toLowerCase().split(' ').join('-'));
-			$('.fn-item').click(function () {
+			$('.fn-item').last().click(function () {
 				var i = $(this).attr('item_index');
 				var s = $(".post[item_index='"+i+"']");
 


### PR DESCRIPTION
Or there will be multiple listeners on a single fn-item, which causes race condition when clicking an item. I suffered a scrolling issue after clicking the nav item and some other strange behaviors when I have 10+ posts until I made this fix.
