### PR TITLE
Fixed issue that prevented using the theme on latest Ghost (1.8.5)

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -4,7 +4,7 @@
     the {body} of the default.hbs template, which contains our header/footer. }}
 
 {{! The big featured header on the homepage, with the site logo and description }}
-<header id="site-head" {{#if @blog.cover}}style="background-image: url({{@blog.cover}})"{{/if}}>
+<header id="site-head" {{#if @blog.cover_image}}style="background-image: url({{@blog.cover_image}})"{{/if}}>
     <div class="vertical">
         <div id="site-head-content" class="inner">
 


### PR DESCRIPTION
`@blog.cover` was renamed to `@blog.cover_image` in latest version of Ghost.